### PR TITLE
Include cstdint in ByteView for completeness

### DIFF
--- a/include/embdebug/ByteView.h
+++ b/include/embdebug/ByteView.h
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 

--- a/lib/server/GdbServer.cpp
+++ b/lib/server/GdbServer.cpp
@@ -1674,7 +1674,10 @@ void GdbServer::rspRemoveMatchpoint() {
   if (cpu->removeMatchpoint(addr, type))
     rsp->putPkt("OK");
   else
-    rsp->putPkt("E01");
+    // Denote 'unsupported' to allow the client to try another matchpoint type.
+    // FIXME: This should be a separate API item for the target, so that we can
+    // also actually indicate a normal error here.
+    rsp->putPkt("");
   return;
 }
 
@@ -1697,7 +1700,10 @@ void GdbServer::rspInsertMatchpoint() {
   if (cpu->insertMatchpoint(addr, type))
     rsp->putPkt("OK");
   else
-    rsp->putPkt("E01");
+    // Denote 'unsupported' to allow the client to try another matchpoint type.
+    // FIXME: This should be a separate API item for the target, so that we can
+    // also actually indicate a normal error here.
+    rsp->putPkt("");
   return;
 }
 

--- a/lib/server/GdbServer.cpp
+++ b/lib/server/GdbServer.cpp
@@ -1659,7 +1659,22 @@ void GdbServer::rspWriteMemBin() {
 //! @todo This doesn't work with icache/immu yet
 
 void GdbServer::rspRemoveMatchpoint() {
-  rsp->putPkt("");
+  ITarget::MatchType type;   // Type of matchpoint
+  uint_reg_t addr;           // Where to remove the matchpoint from
+  uint_addr_t kind;          // TODO: Target-specific data
+
+  if (3 != sscanf(pkt.getRawData(), "z%d,%" PRIxREG ",%" PRIxADDR, &type, &addr, &kind)) {
+    cerr << "Warning: Failed to recognize RSP remove matchpoint command: "
+         << pkt.getRawData() << endl;
+    rsp->putPkt("E01");
+    return;
+  }
+
+
+  if (cpu->removeMatchpoint(addr, type))
+    rsp->putPkt("OK");
+  else
+    rsp->putPkt("E01");
   return;
 }
 
@@ -1668,7 +1683,21 @@ void GdbServer::rspRemoveMatchpoint() {
 //! @todo For now only memory breakpoints are handled
 
 void GdbServer::rspInsertMatchpoint() {
-  rsp->putPkt("");
+  ITarget::MatchType type;   // Type of matchpoint
+  uint_reg_t addr;           // Where to set the matchpoint
+  uint_addr_t kind;          // TODO: Target-specific data
+
+  if (3 != sscanf(pkt.getRawData(), "Z%d,%" PRIxREG ",%" PRIxADDR, &type, &addr, &kind)) {
+    cerr << "Warning: Failed to recognize RSP insert matchpoint command: "
+         << pkt.getRawData() << endl;
+    rsp->putPkt("E01");
+    return;
+  }
+
+  if (cpu->insertMatchpoint(addr, type))
+    rsp->putPkt("OK");
+  else
+    rsp->putPkt("E01");
   return;
 }
 

--- a/vendor/cxxopts-3.0.0/include/cxxopts.hpp
+++ b/vendor/cxxopts-3.0.0/include/cxxopts.hpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define CXXOPTS_HPP_INCLUDED
 
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
cstddef may end up including cstdint in some implementations but to be sure that the appropriate int types really are present we should include cstdint.